### PR TITLE
Feature/use glad alerts download api

### DIFF
--- a/app/src/services/alerts.service.js
+++ b/app/src/services/alerts.service.js
@@ -80,53 +80,20 @@ class AreaService {
 
     static async getGladByGeostore(geostore, range = 365, geohashPrecision = 8) {
         logger.debug(`Obtaining data of glad with last ${range} days`);
-        const gladDataset = config.get('gladDataset');
 
         const firstDay = moment().subtract(range, 'days');
-        const startYearDate = moment().subtract(range, 'days').startOf('year');
-        const dateFromFilter = {
-            year: firstDay.year(),
-            day:  firstDay.diff(startYearDate, 'days')
-        }
-        const dateCurrentFilter = {
-            year: moment().year(),
-            day: moment().diff(moment().startOf('year'), 'days')
-        }
+        const period = `${firstDay.format('YYYY-MM-DD')},${moment().format('YYYY-MM-DD')}`
 
-        let dateQuery = '';
-        if (dateFromFilter.year === dateCurrentFilter.year) {
-            dateQuery += ` year = ${dateFromFilter.year} and julian_day >= ${dateFromFilter.day}`;
-        } else {
-            dateQuery += ' (';
-            for (let i = dateFromFilter.year; i <= dateCurrentFilter.year; i++) {
-                if (i > dateFromFilter.year){
-                    dateQuery +=' or ';
-                }
-                if (i === dateFromFilter.year) {
-                    dateQuery += `(year = '${i}' and julian_day >= ${dateFromFilter.day})`;
-                } else if(i === dateCurrentFilter.day) {
-                    dateQuery += `(year = '${i}' and julian_day <= ${dateCurrentFilter.day})`;
-                } else {
-                    dateQuery += `(year = '${i}')`;
-                }
-            }
-            dateQuery += ')';
-        }
+        const uri = `/glad-alerts/download?period=${period}&geostore=${geostore}&format=json`;
 
-        const query = `select lat, long, julian_day, year from data where ${dateQuery}`;
-        const uri = `/query/${gladDataset}?sql=${query}&geostore=${geostore}`;
-        // const url = 'https://production-api.globalforestwatch.org/v1' + uri;
         logger.info(`Requesting glad alerts with query ${uri}`);
         try {
             const result = await ctRegisterMicroservice.requestToMicroservice({
                 uri,
-                method: 'GET',
-                json: true
+                method: 'GET'
             });
-            // const result = await rp({ uri: url, json: true });
 
-            logger.info('Got glad alerts', result.data.length);
-            return AreaService.parseGladAlerts(result.data, geohashPrecision);
+            return AreaService.parseGladAlerts(JSON.parse(result).data, geohashPrecision);
         } catch (err) {
             throw new Error(err);
         }

--- a/app/src/services/alerts.service.js
+++ b/app/src/services/alerts.service.js
@@ -93,7 +93,7 @@ class AreaService {
                 method: 'GET',
                 json: true
             });
-
+            logger.info('Got glad alerts', result.data.length);
             return AreaService.parseGladAlerts(result.data, geohashPrecision);
         } catch (err) {
             throw new Error(err);

--- a/app/src/services/alerts.service.js
+++ b/app/src/services/alerts.service.js
@@ -90,10 +90,11 @@ class AreaService {
         try {
             const result = await ctRegisterMicroservice.requestToMicroservice({
                 uri,
-                method: 'GET'
+                method: 'GET',
+                json: true
             });
 
-            return AreaService.parseGladAlerts(JSON.parse(result).data, geohashPrecision);
+            return AreaService.parseGladAlerts(result.data, geohashPrecision);
         } catch (err) {
             throw new Error(err);
         }

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -2,7 +2,6 @@
     "service": {
         "port": "PORT"
     },
-    "gladDataset": "GLAD_DATASET",
     "viirsDataset": "VIIRS_DATASET",
     "viirsDatasetTableName": "VIIRS_DATASET_TABLENAME"
 }

--- a/config/default.json
+++ b/config/default.json
@@ -11,7 +11,6 @@
     },
     "gladDatasetSlug": "umd_as_it_happens",
     "viirsDatasetSlug": "viirs",
-    "gladDataset": "e663eb09-04de-4f39-b871-35c6c2ed10b5",
     "viirsDataset": "20cc5eca-8c63-4c41-8e8e-134dcf1e6d76",
     "viirsDatasetTableName": "vnp14imgtdl_nrt_global_7d"
 }

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -54,7 +54,7 @@ spec:
                   name: mssecrets
                   key: API_VERSION
           - name: GLAD_DATASET
-            value: e663eb09-04de-4f39-b871-35c6c2ed10b5
+            value: db34c2d9-77b8-43ee-b101-f499e39d1597
           - name: VIIRS_DATASET
             value: 20cc5eca-8c63-4c41-8e8e-134dcf1e6d76
           - name: VIIRS_DATASET_TABLENAME

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -67,8 +67,6 @@ spec:
                 secretKeyRef:
                   name: mssecrets
                   key: API_VERSION
-          - name: GLAD_DATASET
-            value: db34c2d9-77b8-43ee-b101-f499e39d1597
           - name: VIIRS_DATASET
             value: 20cc5eca-8c63-4c41-8e8e-134dcf1e6d76
           - name: VIIRS_DATASET_TABLENAME

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -13,6 +13,20 @@ spec:
       labels:
         name: {name}
     spec:
+      tolerations:
+      - key: "type"
+        operator: "Equal"
+        value: "gfw"
+        effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type
+                operator: In
+                values:
+                - gfw     
       containers:
       - name: {name}
         image: vizzuality/{name}

--- a/k8s/staging/deployment.yaml
+++ b/k8s/staging/deployment.yaml
@@ -52,8 +52,6 @@ spec:
                 secretKeyRef:
                   name: mssecrets
                   key: API_VERSION
-          - name: GLAD_DATASET
-            value: db34c2d9-77b8-43ee-b101-f499e39d1597
           - name: VIIRS_DATASET
             value: 20cc5eca-8c63-4c41-8e8e-134dcf1e6d76
           - name: VIIRS_DATASET_TABLENAME

--- a/k8s/staging/deployment.yaml
+++ b/k8s/staging/deployment.yaml
@@ -53,7 +53,7 @@ spec:
                   name: mssecrets
                   key: API_VERSION
           - name: GLAD_DATASET
-            value: e663eb09-04de-4f39-b871-35c6c2ed10b5
+            value: db34c2d9-77b8-43ee-b101-f499e39d1597
           - name: VIIRS_DATASET
             value: 20cc5eca-8c63-4c41-8e8e-134dcf1e6d76
           - name: VIIRS_DATASET_TABLENAME


### PR DESCRIPTION
Hi @j8seangel!

I've written some code to point the GLAD download to our new glad-alerts download endpoint instead of querying the dataset directly.

Here's an example call to it:
http://staging-api.globalforestwatch.org/v1/glad-alerts/download?geostore=8a4beb588c28978fe3a032da4e1cb9a9&format=json

This only works on staging currently. If this works for you (and you merge my PR into develop), I'll make a PR from develop into prod when the /glad-alerts/download endpoint is up on production.

Let me know if you have any questions!

Thanks,

Charlie