### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -3,14 +3,14 @@ services:
   develop:
     build: .
     ports:
-      - "4200:4200"
+      - "4201:4201"
     container_name: fw-alerts
     environment:
-      PORT: 4200
+      PORT: 4201
       NODE_PATH: app/src
       CT_REGISTER_MODE: auto
       CT_URL: http://mymachine:9000
-      LOCAL_URL: http://mymachine:4200
+      LOCAL_URL: http://mymachine:4201
       CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
       API_VERSION: v1
       FASTLY_ENABLED: "false"


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Update port to stop it clashing with another microservice